### PR TITLE
Add basic service analysis utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Service Model Analysis
+
+This repository provides basic utilities for analyzing service model data.
+
+## Features
+- Define `ServiceRecord` dataclass to store service information.
+- Calculate average service duration using `average_duration`.
+
+## Usage
+```python
+from service_model_analysis.analysis import ServiceRecord, average_duration
+
+records = [ServiceRecord(service_id=1, duration_minutes=30), ServiceRecord(service_id=2, duration_minutes=45)]
+print(average_duration(records))  # Output: 37.5
+```

--- a/service_model_analysis/analysis.py
+++ b/service_model_analysis/analysis.py
@@ -1,0 +1,17 @@
+"""Simple service model analysis functions."""
+
+from dataclasses import dataclass
+from typing import List
+
+@dataclass
+class ServiceRecord:
+    service_id: int
+    duration_minutes: int
+
+
+def average_duration(records: List[ServiceRecord]) -> float:
+    """Return the average service duration from a list of records."""
+    if not records:
+        return 0.0
+    total = sum(r.duration_minutes for r in records)
+    return total / len(records)

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,9 @@
+from service_model_analysis.analysis import ServiceRecord, average_duration
+
+def test_average_duration():
+    records = [ServiceRecord(service_id=1, duration_minutes=20), ServiceRecord(service_id=2, duration_minutes=40)]
+    assert average_duration(records) == 30
+
+
+def test_average_duration_empty():
+    assert average_duration([]) == 0.0


### PR DESCRIPTION
## Summary
- add Python package `service_model_analysis` with a simple function `average_duration`
- document usage in `README`
- add minimal `.gitignore`
- add tests for average duration

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*